### PR TITLE
New login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>fr.tunaki.stackoverflow</groupId>
   <artifactId>chatexchange</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>ChatExchange</name>
   <description>Simple API to interact with the chat system on Stack Overflow, and the Stack Exchange network.</description>
   <inceptionYear>2016</inceptionYear>

--- a/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
+++ b/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
@@ -39,8 +39,18 @@ public class StackExchangeClient implements AutoCloseable {
 	 * */
 	private HashSet<String> loggedInHosts = new HashSet<>();
 	
+	/**
+	 * The user's e-mail-address
+	 * This needs to be stored in order to login to a site when joining a room.
+	 * With OpenID, this was not necessary because we only had to login once while initializing `StackExchangeClient`
+	 * */
 	private String email = null;
 	
+	/**
+	 * The user's password
+	 * This needs to be stored in order to login to a site when joining a room.
+	 * With OpenID, this was not necessary because we only had to login once while initializing `StackExchangeClient`
+	 * */
 	private String password = null;
 
 	/**
@@ -50,35 +60,38 @@ public class StackExchangeClient implements AutoCloseable {
 	 */
 	public StackExchangeClient(String email, String password) {
 		httpClient = new HttpClient();
-		/*try {
-			//SEOpenIdLogin(email, password);
-			//seLogin(email, password, "stackoverflow.com");
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}*/
 		this.email = email;
 		this.password = password;
 	}
 	
 	/**
 	 * Logs in to s given site
+	 * @param email The user's e-mail-address
+	 * @param password The password
+	 * @param The host of the main site (NOT the chat.*! Use ChatHost.getName())
 	 * */
 	private void seLogin(String email, String password, String host) throws IOException {
+		//The login-form has a hidden field called "fkey" which needs to be sent along with the mail and password
 		Response response = httpClient.get("https://"+host+"/users/login", cookies);
 		String fkey = response.parse().select("input[name='fkey']").val();
 		
 		response = httpClient.post("https://"+host+"/users/login", cookies, "email", email, "password", password, "fkey", fkey);
 		
-		// check logged in
+		// check if login succeeded
 		Response checkResponse = httpClient.get("https://"+host+"/users/current", cookies);
 		if (checkResponse.parse().getElementsByClass("js-inbox-button").first() == null) {
-			LOGGER.debug(response.parse().html());
+			LOGGER.debug(checkResponse.parse().html());
 			throw new IllegalStateException("Unable to login to Stack Exchange.");
 		}
 		
+		//Remember that the user is logged in on that site
 		this.loggedInHosts.add(host);
-	}
+	} // seLogin
 
+	/**
+	 * The old login-flow with OpenID
+	 * @deprecated in 1.2.0. See meta: https://meta.stackexchange.com/q/307647/347985
+	 * */
 	@Deprecated
 	private void SEOpenIdLogin(String email, String password) throws IOException {
 		Response response = httpClient.get("https://openid.stackexchange.com/account/login", cookies);
@@ -112,7 +125,7 @@ public class StackExchangeClient implements AutoCloseable {
 			try {
 				this.seLogin(email, password, mainSiteHost);
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Unable to login on " + mainSiteHost + " for " + host.getBaseUrl(), e);
 				throw new ChatOperationException("Login to " + mainSiteHost + " failed!");
 			}
 		}
@@ -120,18 +133,15 @@ public class StackExchangeClient implements AutoCloseable {
 		if (rooms.stream().anyMatch(r -> r.getHost().equals(host) && r.getRoomId() == roomId)) {
 			throw new ChatOperationException("Cannot join a room you are already in.");
 		}
-		if (rooms.stream().allMatch(r -> !r.getHost().equals(host))) {
-			/*try {
-				siteLogin(host.getName());
-			} catch (IOException e) {
-				throw new UncheckedIOException(e);
-			}*/
-		}
+		
 		Room chatRoom = new Room(host, roomId, httpClient, cookies);
 		rooms.add(chatRoom);
 		return chatRoom;
 	}
 
+	/**
+	 * @deprecated in 1.2.0: This is not required anymore, but maybe someone can re-implement the account creation in the new login-flow?
+	 * */
 	@Deprecated
 	private void siteLogin(String host) throws IOException {
 		Response response = httpClient.get("https://" + host + "/users/login?returnurl=" + URLEncoder.encode("https://" + host + "/", "UTF-8"), cookies);

--- a/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
+++ b/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
@@ -25,19 +25,25 @@ public class StackExchangeClient implements AutoCloseable {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(StackExchangeClient.class);
 
+	/**
+	 * @deprecated in 1.2.0. See meta: https://meta.stackexchange.com/q/307647/347985
+	 */
+	@Deprecated
 	private static final Pattern OPEN_ID_PROVIDER_PATTERN = Pattern.compile("(https://openid.stackexchange.com/user/.*?)\"");
 
+	/**
+	 * @deprecated in 1.2.0. See meta: https://meta.stackexchange.com/q/307647/347985
+	 */
+	@Deprecated
 	private String openIdProvider;
 
 	private HttpClient httpClient;
 	private Map<String, String> cookies = new HashMap<>();
 
-	private List<Room> rooms = new ArrayList<>();
-	
 	/**
-	 * Hosts where the bot is currently logged in
-	 * */
-	private HashSet<String> loggedInHosts = new HashSet<>();
+	 * Rooms the user is currently in
+	 */
+	private List<Room> rooms = new ArrayList<>();
 	
 	/**
 	 * The user's e-mail-address
@@ -82,10 +88,7 @@ public class StackExchangeClient implements AutoCloseable {
 		if (checkResponse.parse().getElementsByClass("js-inbox-button").first() == null) {
 			LOGGER.debug(checkResponse.parse().html());
 			throw new IllegalStateException("Unable to login to Stack Exchange. (Site: " + host + ")");
-		}
-		
-		//Remember that the user is logged in on that site
-		this.loggedInHosts.add(host);
+		} // if
 	} // seLogin
 
 	/**
@@ -120,7 +123,16 @@ public class StackExchangeClient implements AutoCloseable {
 	public Room joinRoom(ChatHost host, int roomId) {
 		String mainSiteHost = host.getName();
 		
-		if (!this.loggedInHosts.contains(mainSiteHost)) {
+		boolean alreadyLoggedIn = false;
+		
+		for (Room room : this.rooms) {
+			if (room.getHost().equals(host)) {
+				alreadyLoggedIn = true;
+				break;
+			} // if
+		} // for rooms
+		
+		if (!alreadyLoggedIn) {
 			//not logged in on that site yet
 			try {
 				this.seLogin(email, password, mainSiteHost);

--- a/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
+++ b/src/main/java/fr/tunaki/stackoverflow/chat/StackExchangeClient.java
@@ -81,7 +81,7 @@ public class StackExchangeClient implements AutoCloseable {
 		Response checkResponse = httpClient.get("https://"+host+"/users/current", cookies);
 		if (checkResponse.parse().getElementsByClass("js-inbox-button").first() == null) {
 			LOGGER.debug(checkResponse.parse().html());
-			throw new IllegalStateException("Unable to login to Stack Exchange.");
+			throw new IllegalStateException("Unable to login to Stack Exchange. (Site: " + host + ")");
 		}
 		
 		//Remember that the user is logged in on that site


### PR DESCRIPTION
Updated the library to support login without OpenID (#6). It's basically an implementation of the idea Sam posted in [our channel](https://stackoverflow.com/c/sobotics/a/139/1).

### API changes

**None of the public APIs was changed.** Bot owners won't need to update their code. They'll just need to import the new version of the library as soon as it's released.

### Internal changes

#### Deprecated methods

* `StackExchangeClient.SEOpenIdLogin()`
* `StackExchangeClient.siteLogin()`

#### New properties

* `StackExchangeClient.email` and `StackExchangeClient.password`
  * Store the user's mail-address and password
  * We need to store this when initializing `StackExchangeClient`, because we have to use the credentials on every site where we want to join a room
* `StackExchangeClient.loggedInHosts`
  * Stores the hosts (the main-sites, not chat.*), where the user is logged in

### Compatibility with hosts

At the moment, only sites that are already using the new login-form are compatible. (for example Stack Overflow, AskUbuntu and meta.SE)

![new login](https://i.stack.imgur.com/xpzkK.png)

`stackexchange.com` seems not to work yet, since it's still using OpenID.